### PR TITLE
Fix autolading.

### DIFF
--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -7,6 +7,4 @@ declare(strict_types=1);
  * Time: 12:40
  */
 
-require_once dirname(__DIR__) . '/vendor/autoload.php';
-
 \Omega\FaultManager\Fault::autoloadCompiledExceptions();


### PR DESCRIPTION
Once installed in a project, application crashes due attempted require of a vendor directory in a place that does not exist where it is installed.